### PR TITLE
NODE_ENVがdevelopmentの時のみreact-hrmeを有効にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "count0.org",
   "version": "0.1.0",
   "scripts": {
-    "start": "$(npm bin)/webpack-dev-server --progress --color --hot --inline --content-base ./dist/",
+    "start": "NODE_ENV=development $(npm bin)/webpack-dev-server --progress --color --hot --inline --content-base ./dist/",
     "build": "$(npm bin)/webpack --progress --color --profile",
-    "publish": "bundle exec jekyll build && $(npm bin)/npm run build && bundle exec s3_website push"
+    "publish": "bundle exec jekyll build && NODE_ENV=production npm run build && bundle exec s3_website push"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,12 @@ module.exports = {
         exclude: /(node_modules|bower_components)/,
         loader: ['babel'],
         query: {
-          presets: ['react-hmre', 'react', 'es2015']
+          presets: ['react', 'es2015'],
+          env: {
+            development: {
+              presets: ['react-hmre']
+            }
+          }
         }
       },
       {


### PR DESCRIPTION
- scriptの実行時に環境変数NODE_ENVをセットするように変更
#11
